### PR TITLE
get-endpoint-for-site.sh now fails if multiple endpoints are found.

### DIFF
--- a/helpers/appdb/get-endpoint-for-site.sh
+++ b/helpers/appdb/get-endpoint-for-site.sh
@@ -21,10 +21,21 @@ APPDB_URL='https://appdb-pi.egi.eu/rest/1.0/sites?listmode=details&flt=%2B%3Dsit
 
 XPATH_SELECTOR="/appdb:appdb/appdb:site[contains(@infrastructure, 'Production') and contains(@status, 'Certified') and contains(@name, \"$1\")]/site:service/siteservice:occi_endpoint_url/text()"
 
-ENDPOINT=`curl -s -k "$APPDB_URL" | $XPATH_BIN -q -e "$XPATH_SELECTOR" 2> /dev/null | head -n 1`
-if [ -z "$ENDPOINT" ]; then
+ENDPOINTS=`curl -s -k "$APPDB_URL" | $XPATH_BIN -q -e "$XPATH_SELECTOR" 2> /dev/null`
+if [ -z "$ENDPOINTS" ]; then
   printf "Couldn't find a production endpoint at $1!\n" >&2
   exit 2
 fi
+
+# Exit with an error in case of multiple endpoints
+NB_ENDPOINTS=$(printf "$ENDPOINTS" | wc -w)
+if [ $NB_ENDPOINTS -gt 1 ]; then
+  printf "Found multiple endpoints for $1:\n" >&2
+  printf "$ENDPOINTS\n" >&2
+  exit 2
+fi
+
+# Return only the first endpoint
+ENDPOINT=`printf "$ENDPOINTS" | head -n 1`
 
 printf "$ENDPOINT\n"

--- a/helpers/occi/public-for-site.sh
+++ b/helpers/occi/public-for-site.sh
@@ -23,14 +23,14 @@ if [ "$?" -ne 0 ]; then
   exit 2
 fi
 
-# FIXME first try to find an interface the ID set to PUBIC, public or floating
+# FIXME first try to find an interface the ID set to PUBLIC, public or floating
 INTIF=$(occi --auth x509 --user-cred "$PROXY_PATH" --voms \
   --endpoint "$ENDPOINT" \
   --action describe --resource network \
   --output-format json_extended | jq -r \
   '.[] | select(.["attributes"]["occi"]["core"]["id"] == "public" or .["attributes"]["occi"]["core"]["id"] == "PUBLIC" or .["attributes"]["occi"]["core"]["id"] == "floating") | .["id"]')
 
-# FIXME secondly try to find an interface the title set to PUBIC, public or floating
+# FIXME secondly try to find an interface the title set to PUBLIC, public or floating
 if [ -z "$INTIF" ]; then
   INTIF=$(occi --auth x509 --user-cred "$PROXY_PATH" --voms \
     --endpoint "$ENDPOINT" \


### PR DESCRIPTION
Exit with an error and endpoints list in case one site is configured with multiple endpoints.