### PR TITLE
attach-for-site: correctly format network returned bo OCCI OS

### DIFF
--- a/helpers/occi/attach-for-site.sh
+++ b/helpers/occi/attach-for-site.sh
@@ -33,6 +33,7 @@ if [ "$?" -ne 0 ]; then
   exit 4
 fi
 
+# Remove OCCI-OS hardcored /network/ prefix
 occi --auth x509 --user-cred "$PROXY_PATH" --voms \
      --endpoint "$ENDPOINT" \
-     --action link --resource "$2" --link "${ENDPOINT%/}/network/$3"
+     --action link --resource "$2" --link "${ENDPOINT%/}/network/${3#/network/}"


### PR DESCRIPTION
`OCCI-OS` will return `/network/PUBLIC`, we need to remove the `/network/` prefix to make the other scripts work.