### PR TITLE
list-sites: list only sites that are supporting the "current" VO.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains scripts that have been initially created by [Boris Para
 * Information about the sites is taken from the AppDB
   * AppDB gets information from GocDB and from the Top BDII gathering information from all the Site BDIIs
   * Endpoints that are not OK in [ARGO](http://argo.egi.eu/lavoisier/status_report-site?report=Critical&Fedcloud=true&accept=html) are not used
-* `list-sites.sh` does not filter sites, some might not support a specific VO
+* `list-sites.sh` lists sites supporting the VO returned by `voms-proxy-info -vo`
 * Interaction with the sites is done using OCCI
 * All unsuccessful deployment attempts are cleaned
 * By default all VM successfully instantiated are deleted, set `KEEP_VMS=1`

--- a/list-sites.sh
+++ b/list-sites.sh
@@ -11,9 +11,23 @@ fi
 set -o pipefail
 set -e
 
-XPATH_BIN='xpath'
-APPDB_URL='https://appdb-pi.egi.eu/rest/1.0/sites?listmode=details&flt=%2B%3Dsite.supports%3A1%20%2B%3Dsite.hasinstances%3A1%0A'
+# Filter (flt parameter) has to be URL encoded
+# AppDB REST API filtering: https://wiki.egi.eu/wiki/EGI_AppDB_REST_API_v1.0#Paging_and_Filtering
+# URL encode/decode: http://urldecode.org/
 
+# Filter all sites having at least one OCCI endpoint and one image obtained from the AppDB
+# +=site.supports:1 +=site.hasinstances:1
+# FILTER='%2B%3Dsite.supports%3A1%20%2B%3Dsite.hasinstances%3A1%0A'
+
+# Filter all sites having at least one OCCI endpoint and one image obtained from the AppDB
+# and supporting the VO used by the available voms proxy, like fedcloud.egi.eu
+# +=site.supports:1 +=site.hasinstances:1 +=vo.name:fedcloud.egi.eu
+VO=$(voms-proxy-info -vo)
+FILTER="%2b%3dsite.supports%3a1+%2b%3dsite.hasinstances%3a1+%2b%3dvo.name%3a${VO}%0d%0a"
+
+APPDB_URL="https://appdb-pi.egi.eu/rest/1.0/sites?listmode=details&flt=${FILTER}"
+
+XPATH_BIN='xpath'
 XPATH_SELECTOR='/appdb:appdb/appdb:site[contains(@infrastructure, "Production") and contains(@status, "Certified")]/site:service[contains(@type, "occi")]/../@name'
 
 SITES=`curl -s -k "$APPDB_URL" | $XPATH_BIN -q -e "$XPATH_SELECTOR" 2> /dev/null | awk -F '=' '{ print $2 }' | sort -u | sed 's/"//g'`


### PR DESCRIPTION
Document and filter sites supporting the VO returned by `voms-proxy-info -vo`.